### PR TITLE
Add Snail Beacon Event feature

### DIFF
--- a/app/src/main/res/layout/activity_how_to_play.xml
+++ b/app/src/main/res/layout/activity_how_to_play.xml
@@ -46,11 +46,15 @@ Every few minutes, it may unleash a new behavior:\n\n
 The snail disappears from the map temporarily.\n\n
 🎭 Fake Snail\n
 It spawns a false marker to mislead you.\n\n
-⚡ Teleport\n
-It jumps forward a short distance without warning.\n\n
-Good luck.\n
-It’s slow…\n
-…but it never, ever stops."
+  ⚡ Teleport\n
+  It jumps forward a short distance without warning.\n\n
+  🐌 Snail Beacon Event\n
+  Random beacons appear on the map during the day. Reach one before the snail
+  to push it back 50 meters. If the snail gets there first, its speed doubles
+  for the next 24 hours.\n\n
+  Good luck.\n
+  It’s slow…\n
+  …but it never, ever stops."
 
             />
 


### PR DESCRIPTION
## Summary
- spawn snail beacon randomly during the day and handle capture events
- double snail speed for 24 hours if the snail reaches the beacon
- push snail back 50m if player reaches the beacon
- describe Snail Beacon Event in How to Play panel

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68712e10d8148325abfce9e4ee48c91a