### PR TITLE
Fix quit button to stop service and reset state

### DIFF
--- a/app/src/main/java/com/example/itfollows/MainActivity.java
+++ b/app/src/main/java/com/example/itfollows/MainActivity.java
@@ -528,7 +528,12 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         Button buttonQuitNo = findViewById(R.id.buttonQuitNo);
 
         buttonQuitYes.setOnClickListener(v -> {
+            // Stop any running game service and clear its persisted state
             stopService(new Intent(this, GameService.class));
+            GameService.clearSavedState(this);
+
+            // Clear any saved game progress so a new game starts fresh
+            clearGameStatePrefs();
 
             Intent intent = new Intent(this, MainMenuActivity.class);
             intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);


### PR DESCRIPTION
## Summary
- ensure quitting the game stops `GameService`
- clear saved state when the user confirms quit

## Testing
- `./gradlew test` *(fails: Unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6871467f9ab48325b29ea09196fb212d