### PR TITLE
Add snail trail persistence

### DIFF
--- a/app/src/main/java/com/example/itfollows/GameService.java
+++ b/app/src/main/java/com/example/itfollows/GameService.java
@@ -30,6 +30,9 @@ import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.maps.model.LatLng;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class GameService extends Service {
     private static final int NOTIFICATION_ID = 123;
@@ -82,6 +85,7 @@ public class GameService extends Service {
                         intent.getDoubleExtra("snail_lat", 0),
                         intent.getDoubleExtra("snail_lng", 0)
                 );
+                saveSnailTrailPoint(snailPosition);
             }
 
             // Retrieve game settings if passed
@@ -112,6 +116,7 @@ public class GameService extends Service {
                         intent.getDoubleExtra("snail_lng", 0)
 
                 );
+                saveSnailTrailPoint(snailPosition);
             }
         startForeground(NOTIFICATION_ID, notification);
 
@@ -204,6 +209,7 @@ public class GameService extends Service {
         double newSnailLat = snailPosition.latitude + (speedDegrees * Math.sin(angle));
         double newSnailLng = snailPosition.longitude + (speedDegrees * Math.cos(angle));
         snailPosition = new LatLng(newSnailLat, newSnailLng);
+        saveSnailTrailPoint(snailPosition);
         Log.d(TAG, "Snail moved to: " + snailPosition);
     }
 
@@ -436,5 +442,27 @@ public class GameService extends Service {
         Log.d(TAG, "Clearing saved GameService state.");
         SharedPreferences prefs = context.getSharedPreferences(PREFS_GAME_SERVICE_STATE, MODE_PRIVATE);
         prefs.edit().clear().apply();
+    }
+
+    /**
+     * Append the given point to the persistent snail trail stored in SharedPreferences.
+     * Each point is stored as a JSON object within a JSON array under the key
+     * "trailPoints" in the "SnailTrail" preference file.
+     */
+    private void saveSnailTrailPoint(LatLng newPoint) {
+        SharedPreferences trailPrefs = getSharedPreferences("SnailTrail", MODE_PRIVATE);
+        String trailJson = trailPrefs.getString("trailPoints", "[]");
+
+        try {
+            JSONArray trailArray = new JSONArray(trailJson);
+            JSONObject point = new JSONObject();
+            point.put("lat", newPoint.latitude);
+            point.put("lng", newPoint.longitude);
+            trailArray.put(point);
+
+            trailPrefs.edit().putString("trailPoints", trailArray.toString()).apply();
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- track snail path in `GameService` by saving each position to a `JSONArray` in shared prefs
- store initial snail position in trail when service starts
- persist new trail point whenever the snail moves

## Testing
- `./gradlew test` *(fails: unable to download gradle due to restricted network)*

------
https://chatgpt.com/codex/tasks/task_e_688102f54b3c8325a9404dffb682043e