### PR TITLE
Fix snail trail restoration when map uninitialized

### DIFF
--- a/app/src/main/java/com/example/itfollows/MainActivity.java
+++ b/app/src/main/java/com/example/itfollows/MainActivity.java
@@ -1217,6 +1217,10 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     private void drawSnailTrail() {
     }
     private void restoreSnailTrail() {
+        if (mMap == null) {
+            Log.w(TAG_MAIN_ACTIVITY, "Map not ready; skipping trail restore");
+            return;
+        }
         SharedPreferences trailPrefs = getSharedPreferences("SnailTrail", MODE_PRIVATE);
         String trailJson = trailPrefs.getString("trailPoints", "[]");
 
@@ -2509,6 +2513,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     @Override
     public void onMapReady(@NonNull GoogleMap googleMap) {
         mMap = googleMap;
+        restoreSnailTrail();
         mMap.getUiSettings().setZoomControlsEnabled(true);
         mMap.setOnCameraMoveStartedListener(reason -> {
             if (reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE) {


### PR DESCRIPTION
## Summary
- avoid NullPointerException in `restoreSnailTrail` by exiting if map isn't ready
- draw the snail trail as soon as map loads

## Testing
- `./gradlew test --daemon` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6881194caf54832580702b82b664d004