### PR TITLE
Fix map location enable sequence

### DIFF
--- a/app/src/main/java/com/example/itfollows/MainActivity.java
+++ b/app/src/main/java/com/example/itfollows/MainActivity.java
@@ -1965,7 +1965,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
                     }
                     lastRewardCheckLocation = currentPlayerLocation;
-                    if (mMap != null && !hasSpawnedSnail && mMap.getMyLocation() != null && currentPlayerLocation != null) {
+                    if (mMap != null && !hasSpawnedSnail && currentPlayerLocation != null) {
                         // If resuming from a killed state and game state was loaded, snail might already be "spawned" conceptually
                         // Check if snailPosition is already set from loaded state
                         if (hasSpawnedSnail || snailPosition != null) {
@@ -2020,11 +2020,11 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         locationRequest.setInterval(250); // Desired interval for active location updates
         locationRequest.setFastestInterval(250); // Fastest interval if available from other apps
         locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
-        fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, getMainLooper());
         if (mMap != null) {
             mMap.setMyLocationEnabled(true);
             mMap.getUiSettings().setMyLocationButtonEnabled(true);
         }
+        fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, getMainLooper());
     }
     // Add this method to your MainActivity.java
 


### PR DESCRIPTION
## Summary
- ensure the map location layer is enabled before starting location requests
- remove redundant `getMyLocation` check in callback

## Testing
- `gradle assembleDebug -x lint -x test --console=plain` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_688786a1158483259f5f9c823d3154de