### PR TITLE
Improve logging and resume location updates

### DIFF
--- a/app/src/main/java/com/example/itfollows/GameService.java
+++ b/app/src/main/java/com/example/itfollows/GameService.java
@@ -107,8 +107,11 @@ public class GameService extends Service {
             stopSelf(); // Or attempt to load from a more robust saved state.
             return START_NOT_STICKY;
         }
-            Notification notification = createNotification("Snail is hunting...");
-            startForeground(NOTIFICATION_ID, notification);
+        Notification notification = createNotification("Snail is hunting...");
+        Log.d(TAG, "Starting foreground service");
+        Log.d(TAG, "Ensuring service stays in foreground");
+        startForeground(NOTIFICATION_ID, notification);
+        Log.d(TAG, "Foreground service started");
             if (!isGameRunning) { // Start game logic only if not already running (e.g. from a previous start command)
                 isGameRunning = true;
                 startLocationUpdates();
@@ -124,6 +127,7 @@ public class GameService extends Service {
                 );
                 saveSnailTrailPoint(snailPosition);
             }
+        Log.d(TAG, "Ensuring service stays in foreground");
         startForeground(NOTIFICATION_ID, notification);
 
         startLocationUpdates();
@@ -194,6 +198,7 @@ public class GameService extends Service {
 
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
             fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, Looper.getMainLooper());
+            Log.d(TAG, "Location updates registered");
         } else {
             Log.e(TAG, "Location permission not granted for service. Stopping.");
             stopGameAndService(); // Or handle differently

--- a/app/src/main/java/com/example/itfollows/MainActivity.java
+++ b/app/src/main/java/com/example/itfollows/MainActivity.java
@@ -419,6 +419,8 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     @Override
     protected void onCreate(Bundle savedInstanceState) {
 
+        Log.d(TAG_MAIN_ACTIVITY, "onCreate called");
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_maps);
         SharedPreferences statePrefs = getSharedPreferences(PREFS_GAME_STATE, MODE_PRIVATE);
@@ -1260,6 +1262,14 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     };
 
     private void updateDistanceDisplay(float result) {
+        if (snailDistanceText == null) return;
+
+        if (useImperial) {
+            double feet = result * 3.28084;
+            snailDistanceText.setText(String.format(Locale.US, "Snail: %.1f ft\nSpeed: %s", feet, currentSnailSpeedSetting));
+        } else {
+            snailDistanceText.setText(String.format(Locale.US, "Snail: %.1f m\nSpeed: %s", result, currentSnailSpeedSetting));
+        }
     }
 
     private void activateShellShield() {
@@ -1995,6 +2005,12 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         }
         fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, getMainLooper());
     }
+
+    private void stopLocationUpdates() {
+        if (fusedLocationClient != null && locationCallback != null) {
+            fusedLocationClient.removeLocationUpdates(locationCallback);
+        }
+    }
     // Add this method to your MainActivity.java
 
     private void checkLocationPermission() {
@@ -2412,6 +2428,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     @Override
     protected void onStart() { // Or onResume
         super.onStart();
+        Log.d(TAG_MAIN_ACTIVITY, "onStart called");
         // Activity is visible again
         isInBackground = false;
         IntentFilter filter = new IntentFilter();
@@ -2434,6 +2451,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     @Override
     protected void onStop() { // Or onPause
         super.onStop();
+        Log.d(TAG_MAIN_ACTIVITY, "onStop called");
         // Mark that the activity is no longer in the foreground
         isInBackground = true;
         LocalBroadcastManager.getInstance(this).unregisterReceiver(gameStateReceiver);
@@ -2533,6 +2551,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     @Override
     protected void onPause() {
         super.onPause();
+        Log.d(TAG_MAIN_ACTIVITY, "onPause called");
 
         SharedPreferences.Editor editor = getSharedPreferences("GameSettings", MODE_PRIVATE).edit();
         editor.putBoolean("vibration", false);
@@ -2550,6 +2569,8 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
         LocalBroadcastManager.getInstance(this).registerReceiver(gameOverReceiver,
                 new IntentFilter("GAME_OVER"));
+
+        stopLocationUpdates();
     }
 
 
@@ -2564,6 +2585,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     @Override
     protected void onResume() {
         super.onResume();
+        Log.d(TAG_MAIN_ACTIVITY, "onResume called");
         // Activity returned to foreground
         isInBackground = false;
         // Minigame activities have ended when we return here
@@ -2582,6 +2604,20 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         // Register game over receiver
         LocalBroadcastManager.getInstance(this).registerReceiver(gameOverReceiver,
                 new IntentFilter("GAME_OVER"));
+
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED) {
+            startLocationUpdates();
+        }
+
+        if (currentPlayerLocation != null && snailPosition != null) {
+            float[] results = new float[1];
+            Location.distanceBetween(
+                    currentPlayerLocation.latitude, currentPlayerLocation.longitude,
+                    snailPosition.latitude, snailPosition.longitude,
+                    results);
+            updateDistanceDisplay(results[0]);
+        }
     }
 
     private void loadSelectedSnailSprite() {
@@ -2593,6 +2629,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
         @Override
         protected void onDestroy() {
+            Log.d(TAG_MAIN_ACTIVITY, "onDestroy called");
             if (saltBombCooldownTimer != null) {
                 saltBombCooldownTimer.cancel();
             }
@@ -2601,6 +2638,8 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
             SharedPreferences.Editor editor = getSharedPreferences("GameSettings", MODE_PRIVATE).edit();
             editor.putBoolean("vibration", true);
             editor.apply();
+
+            stopLocationUpdates();
 
             super.onDestroy();
         }


### PR DESCRIPTION
## Summary
- add lifecycle logs in `MainActivity`
- re-register `LocationCallback` on resume and remove updates on pause
- implement `updateDistanceDisplay` so distance UI resumes
- log foreground service start and location update registration

## Testing
- `./gradlew test` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6887b88e5d3c832580e72bba9614fd6f