### PR TITLE
Hide minigame test menu

### DIFF
--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -316,7 +316,7 @@
         android:background="#DD000000"
         android:orientation="vertical"
         android:padding="16dp"
-        android:visibility="visible"> <!-- Set to 'gone' later -->
+        android:visibility="gone">
 
         <TextView
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- hide the minigame test menu in `activity_maps.xml` by default

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_688ced49e338832587fc5c696b170f7b