### PR TITLE
feat: add background and transparent buttons to coin flip

### DIFF
--- a/app/src/main/res/layout/activity_coin_flip_minigame.xml
+++ b/app/src/main/res/layout/activity_coin_flip_minigame.xml
@@ -1,6 +1,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
-    android:background="#000000"
+    android:background="@drawable/heads_tails"
     android:padding="24dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -20,12 +20,14 @@
     <Button
         android:id="@+id/headsBtn"
         android:text="Heads"
+        android:background="@android:color/transparent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
 
     <Button
         android:id="@+id/tailsBtn"
         android:text="Tails"
+        android:background="@android:color/transparent"
         android:layout_marginTop="16dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>


### PR DESCRIPTION
## Summary
- use `heads_tails.png` as the coin flip minigame background
- make Heads and Tails buttons transparent to blend with the background

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*

------
https://chatgpt.com/codex/tasks/task_e_688cf7f3f98083259c96cb1566f4a688