### PR TITLE
Use shared inventory panel layout

### DIFF
--- a/app/src/main/java/com/example/itfollows/MainActivity.java
+++ b/app/src/main/java/com/example/itfollows/MainActivity.java
@@ -164,6 +164,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     private boolean startChaseWhenMapReady = false;
     private RelativeLayout inventoryPanel;
     private Button inventoryButton, useSaltBombBtn;
+    private ImageButton closeInventoryBtn;
     private TextView saltBombLabel;
     private SharedPreferences powerUpPrefs;
     private SharedPreferences.Editor powerUpEditor;
@@ -695,6 +696,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
         inventoryButton = findViewById(R.id.inventoryButton);
         inventoryPanel = findViewById(R.id.inventoryPanel);
+        closeInventoryBtn = findViewById(R.id.closeInventoryBtn);
         useSaltBombBtn = findViewById(R.id.useSaltBombBtn);
         saltBombLabel = findViewById(R.id.saltBombLabel);
 
@@ -707,6 +709,8 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
                 inventoryPanel.bringToFront(); // Ensure it's on top
             }
         });
+
+        closeInventoryBtn.setOnClickListener(v -> inventoryPanel.setVisibility(View.GONE));
 
         useSaltBombBtn.setOnClickListener(v -> {
             int count = powerUpPrefs.getInt("saltBomb", 0);

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -66,102 +66,11 @@
         android:elevation="1dp"
         android:text="Inventory" />
 
-    <RelativeLayout
-        android:id="@+id/inventoryPanel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+    <include
+        layout="@layout/inventory_panel"
         android:layout_centerInParent="true"
-        tools:visibility="visible"
         android:visibility="gone"
-        android:background="#FEFFFE"
-        android:padding="16dp">
-
-    <!-- 🧊 Salt Bomb -->
-    <TextView
-        android:id="@+id/saltBombLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="🧊 Salt Bomb (x0)"
-        android:textColor="#000000"
-        android:textSize="18sp" />
-
-
-    <!-- If you want them, add them back like in your standalone inventory_panel.xml -->
-    <TextView
-        android:id="@+id/saltBombDesc"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/saltBombLabel"
-        android:text="0"
-        android:textColor="#000000"
-        android:textSize="0dp"
-        android:layout_marginTop="2dp"/>
-
-    <Button
-        android:id="@+id/useSaltBombBtn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/saltBombDesc"     android:text="Use"
-        android:layout_marginTop="6dp" />
-
-    <!-- 🌀 Decoy Shell -->
-    <TextView
-        android:id="@+id/decoyLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/useSaltBombBtn"
-        android:text="🌀 Decoy Shell (x0)"
-        android:textColor="#000000"
-        android:textSize="18sp"
-        android:layout_marginTop="16dp" />
-
-    <TextView
-        android:id="@+id/decoyDesc"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/decoyLabel"
-        android:text=""
-        android:textColor="#000000"
-        android:textSize="0dp"
-        android:layout_marginTop="2dp"/>
-
-    <Button
-        android:id="@+id/useDecoyBtn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/decoyDesc"
-        android:text="Use"
-        android:layout_marginTop="6dp" />
-
-    <!-- 🛡️ Shell Shield -->
-    <TextView
-        android:id="@+id/shieldLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/useDecoyBtn"
-        android:text="🛡️ Shell Shield (x0)"
-        android:textColor="#000000"
-        android:textSize="18sp"
-        android:layout_marginTop="16dp" />
-
-    <TextView
-        android:id="@+id/shieldDesc"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/shieldLabel"
-        android:text=""
-        android:textColor="#000000"
-        android:textSize="0dp"
-        android:layout_marginTop="2dp"/>
-
-    <Button
-        android:id="@+id/useShieldBtn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/shieldDesc"
-        android:text="Use"
-        android:layout_marginTop="6dp" />
-    </RelativeLayout>
+        tools:visibility="visible" />
 
     <ImageButton
         android:id="@+id/shopToggleButton"

--- a/app/src/main/res/layout/inventory_panel.xml
+++ b/app/src/main/res/layout/inventory_panel.xml
@@ -27,6 +27,14 @@
         android:src="@drawable/inventory" />
 
     <TextView
+        android:id="@+id/saltBombLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="🧊 Salt Bomb (x0)"
+        android:textColor="#000000"
+        android:textSize="18sp" />
+
+    <TextView
         android:id="@+id/saltBombDesc"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -48,6 +56,16 @@
         android:layout_marginEnd="122dp"
         android:background="@android:color/transparent"
         android:text="" />
+
+    <TextView
+        android:id="@+id/decoyLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/useSaltBombBtn"
+        android:layout_marginTop="16dp"
+        android:text="🌀 Decoy Shell (x0)"
+        android:textColor="#000000"
+        android:textSize="18sp" />
 
     <TextView
         android:id="@+id/decoyDesc"
@@ -73,6 +91,16 @@
         android:text="" />
 
     <TextView
+        android:id="@+id/shieldLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/useDecoyBtn"
+        android:layout_marginTop="16dp"
+        android:text="🛡️ Shell Shield (x0)"
+        android:textColor="#000000"
+        android:textSize="18sp" />
+
+    <TextView
         android:id="@+id/shieldDesc"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -92,5 +120,15 @@
         android:layout_marginEnd="122dp"
         android:background="@android:color/transparent"
         android:text="" />
+
+    <ImageButton
+        android:id="@+id/closeInventoryBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentTop="true"
+        android:background="@android:color/transparent"
+        android:contentDescription="Close inventory"
+        android:src="@android:drawable/ic_menu_close_clear_cancel" />
 
 </RelativeLayout>


### PR DESCRIPTION
## Summary
- Replace inline inventory panel in `activity_maps.xml` with a reusable include of `inventory_panel`
- Flesh out `inventory_panel.xml` with text labels for Salt Bomb, Decoy Shell and Shell Shield
- Add a close button that hides the inventory panel

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_688d08990a048325aceee83b4c0b7ebe