### PR TITLE
Ensure avatar photo imports are padded before scaling

### DIFF
--- a/app/src/main/java/com/example/itfollows/avatar/AvatarImporter.java
+++ b/app/src/main/java/com/example/itfollows/avatar/AvatarImporter.java
@@ -1,0 +1,42 @@
+package com.example.itfollows.avatar;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+
+/**
+ * Utility class for importing arbitrary photos into avatar-sized bitmaps.
+ */
+public final class AvatarImporter {
+    private AvatarImporter(){}
+
+    /**
+     * Creates an avatar-sized {@link Bitmap} from an arbitrary source image.
+     * <p>
+     * The source is first placed, without scaling, at the center of a new
+     * transparent square canvas whose side equals the larger of the source's
+     * width or height. This pads the shorter dimension with transparency so the
+     * entire image is preserved. The padded square is then scaled to
+     * {@link AvatarConfig#WIDTH}×{@link AvatarConfig#HEIGHT} using bilinear
+     * filtering.
+     *
+     * @param src source bitmap; caller retains ownership
+     * @return a new bitmap of size {@code AvatarConfig.WIDTH × AvatarConfig.HEIGHT}
+     *         or {@code null} if {@code src} is {@code null}
+     */
+    public static Bitmap importPhoto(Bitmap src) {
+        if (src == null) return null;
+        int w = src.getWidth();
+        int h = src.getHeight();
+        int size = Math.max(w, h);
+
+        Bitmap square = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        square.eraseColor(Color.TRANSPARENT);
+        Canvas c = new Canvas(square);
+        c.drawBitmap(src, (size - w) / 2f, (size - h) / 2f, null);
+
+        Bitmap out = Bitmap.createScaledBitmap(square, AvatarConfig.WIDTH, AvatarConfig.HEIGHT, true);
+        square.recycle();
+        return out;
+    }
+}


### PR DESCRIPTION
## Summary
- add `AvatarImporter.importPhoto` that centers source images on a transparent square and scales them to avatar dimensions
- document the padding behavior in Javadoc

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ef19c2648325bfe0b6d7f9e5bd2a