### PR TITLE
Use constants for game broadcast actions

### DIFF
--- a/app/src/main/java/com/example/itfollows/GameActivity.java
+++ b/app/src/main/java/com/example/itfollows/GameActivity.java
@@ -2457,8 +2457,6 @@ public class GameActivity extends AppCompatActivity implements OnMapReadyCallbac
         filter.addAction(GameService.ACTION_GAME_STATE_UPDATE);
         filter.addAction(GameService.ACTION_GAME_OVER);
         LocalBroadcastManager.getInstance(this).registerReceiver(gameStateReceiver, filter);
-        LocalBroadcastManager.getInstance(this).registerReceiver(gameStateReceiver,
-                new IntentFilter("GAME_STATE_UPDATE"));
         if (isGameServiceRunning()) {
             isGameServiceActive = true; // Acknowledge service is running
             Log.d(TAG_MAIN_ACTIVITY, "Activity starting, GameService already running. Will listen for updates.");
@@ -2596,7 +2594,7 @@ public class GameActivity extends AppCompatActivity implements OnMapReadyCallbac
         }
 
         LocalBroadcastManager.getInstance(this).registerReceiver(gameOverReceiver,
-                new IntentFilter("GAME_OVER"));
+                new IntentFilter(GameService.ACTION_GAME_OVER));
         stopLocationUpdates();
     }
 
@@ -2630,7 +2628,7 @@ public class GameActivity extends AppCompatActivity implements OnMapReadyCallbac
         coinBalanceText.setText("🪙 " + balance);
         // Register game over receiver
         LocalBroadcastManager.getInstance(this).registerReceiver(gameOverReceiver,
-                new IntentFilter("GAME_OVER"));
+                new IntentFilter(GameService.ACTION_GAME_OVER));
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
                 == PackageManager.PERMISSION_GRANTED) {
             startLocationUpdates();

--- a/app/src/main/java/com/example/itfollows/GameService.java
+++ b/app/src/main/java/com/example/itfollows/GameService.java
@@ -15,6 +15,8 @@ import com.google.android.gms.location.Priority;
 
 public class GameService extends Service {
     private static final int NOTIF_ID = 42;
+    public static final String ACTION_GAME_STATE_UPDATE = "ACTION_GAME_STATE_UPDATE";
+    public static final String ACTION_GAME_OVER = "ACTION_GAME_OVER";
     private FusedLocationProviderClient fused;
     private PendingIntent locationPI;
 

--- a/app/src/main/java/com/example/itfollows/MainActivity.java
+++ b/app/src/main/java/com/example/itfollows/MainActivity.java
@@ -39,7 +39,7 @@ public class MainActivity extends AppCompatActivity {
         super.onResume();
         LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(this);
         lbm.registerReceiver(tickReceiver, new IntentFilter("GAME_TICK"));
-        lbm.registerReceiver(gameOverReceiver, new IntentFilter("ACTION_GAME_OVER"));
+        lbm.registerReceiver(gameOverReceiver, new IntentFilter(GameService.ACTION_GAME_OVER));
         updateDistanceUI();
     }
 

--- a/app/src/main/java/com/example/itfollows/SnailPhysics.java
+++ b/app/src/main/java/com/example/itfollows/SnailPhysics.java
@@ -50,7 +50,8 @@ public class SnailPhysics {
 
         double d = GeoMath.haversineMeters(moved[0], moved[1], player[0], player[1]);
         if (d < repo.getGameOverRadiusMeters()) {
-            LocalBroadcastManager.getInstance(app).sendBroadcast(new Intent("ACTION_GAME_OVER"));
+            LocalBroadcastManager.getInstance(app).sendBroadcast(
+                    new Intent(GameService.ACTION_GAME_OVER));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Define ACTION_GAME_STATE_UPDATE and ACTION_GAME_OVER in GameService
- Replace string literals with shared broadcast constants in SnailPhysics, GameActivity, and MainActivity
- Consolidate GameActivity.onStart to a single IntentFilter and compare broadcast actions via constants

## Testing
- ⚠️ `./gradlew test` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06f3390208325983bdcd3459364d1