### PR TITLE
Use constants for game broadcast actions

### DIFF
--- a/app/src/main/java/com/example/itfollows/GameActivity.java
+++ b/app/src/main/java/com/example/itfollows/GameActivity.java
@@ -2457,8 +2457,6 @@ public class GameActivity extends AppCompatActivity implements OnMapReadyCallbac
         filter.addAction(GameService.ACTION_GAME_STATE_UPDATE);
         filter.addAction(GameService.ACTION_GAME_OVER);
         LocalBroadcastManager.getInstance(this).registerReceiver(gameStateReceiver, filter);
-        LocalBroadcastManager.getInstance(this).registerReceiver(gameStateReceiver,
-                new IntentFilter("GAME_STATE_UPDATE"));
         if (isGameServiceRunning()) {
             isGameServiceActive = true; // Acknowledge service is running
             Log.d(TAG_MAIN_ACTIVITY, "Activity starting, GameService already running. Will listen for updates.");
@@ -2596,7 +2594,7 @@ public class GameActivity extends AppCompatActivity implements OnMapReadyCallbac
         }
 
         LocalBroadcastManager.getInstance(this).registerReceiver(gameOverReceiver,
-                new IntentFilter("GAME_OVER"));
+                new IntentFilter(GameService.ACTION_GAME_OVER));
         stopLocationUpdates();
     }
 
@@ -2630,7 +2628,7 @@ public class GameActivity extends AppCompatActivity implements OnMapReadyCallbac
         coinBalanceText.setText("🪙 " + balance);
         // Register game over receiver
         LocalBroadcastManager.getInstance(this).registerReceiver(gameOverReceiver,
-                new IntentFilter("GAME_OVER"));
+                new IntentFilter(GameService.ACTION_GAME_OVER));
         if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
                 == PackageManager.PERMISSION_GRANTED) {
             startLocationUpdates();

--- a/app/src/main/java/com/example/itfollows/GameService.java
+++ b/app/src/main/java/com/example/itfollows/GameService.java
@@ -3,8 +3,11 @@ package com.example.itfollows;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.IBinder;
+import android.util.Log;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
@@ -15,6 +18,8 @@ import com.google.android.gms.location.Priority;
 
 public class GameService extends Service {
     private static final int NOTIF_ID = 42;
+    public static final String ACTION_GAME_STATE_UPDATE = "ACTION_GAME_STATE_UPDATE";
+    public static final String ACTION_GAME_OVER = "ACTION_GAME_OVER";
     private FusedLocationProviderClient fused;
     private PendingIntent locationPI;
 
@@ -65,5 +70,18 @@ public class GameService extends Service {
 
     private void scheduleReconcile() {
         ReconcileScheduler.schedule(getApplicationContext());
+    }
+
+    /**
+     * Clears any persisted game state so a new game can start fresh.
+     *
+     * @param context context used to access shared preferences
+     */
+    public static void clearSavedState(Context context) {
+        SharedPreferences.Editor editor =
+                context.getSharedPreferences("SnailGameState", Context.MODE_PRIVATE).edit();
+        editor.clear();
+        editor.apply();
+        Log.d("GameService", "Saved game state cleared.");
     }
 }

--- a/app/src/main/java/com/example/itfollows/MainActivity.java
+++ b/app/src/main/java/com/example/itfollows/MainActivity.java
@@ -39,7 +39,7 @@ public class MainActivity extends AppCompatActivity {
         super.onResume();
         LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(this);
         lbm.registerReceiver(tickReceiver, new IntentFilter("GAME_TICK"));
-        lbm.registerReceiver(gameOverReceiver, new IntentFilter("ACTION_GAME_OVER"));
+        lbm.registerReceiver(gameOverReceiver, new IntentFilter(GameService.ACTION_GAME_OVER));
         updateDistanceUI();
     }
 

--- a/app/src/main/java/com/example/itfollows/MainMenuActivity.java
+++ b/app/src/main/java/com/example/itfollows/MainMenuActivity.java
@@ -28,12 +28,6 @@ public class MainMenuActivity extends AppCompatActivity {
         Log.d("MainMenuActivity", "GameService stopped (reset for new game).");
     }
 
-    private void clearSavedState() {
-        SharedPreferences.Editor editor = getSharedPreferences("SnailGameState", MODE_PRIVATE).edit();
-        editor.clear();
-        editor.apply();
-        Log.d("MainMenuActivity", "Saved game state cleared.");
-    }
     public void onStartNewGameClick(View view) {
         // Step 1: Clear the power-up inventory
         resetPowerUps();
@@ -80,7 +74,7 @@ public class MainMenuActivity extends AppCompatActivity {
         Button newGameButton = findViewById(R.id.buttonStart);
         newGameButton.setOnClickListener(v -> {
             stopGameServiceAndReset(); // Stop current game
-            clearSavedState();         // Optional: clear saved state
+            GameService.clearSavedState(this); // Optional: clear saved state
             Intent intent = new Intent(this, GameActivity.class);
             intent.putExtra("isNewGame", true);
             startActivity(intent);

--- a/app/src/main/java/com/example/itfollows/SnailPhysics.java
+++ b/app/src/main/java/com/example/itfollows/SnailPhysics.java
@@ -50,7 +50,8 @@ public class SnailPhysics {
 
         double d = GeoMath.haversineMeters(moved[0], moved[1], player[0], player[1]);
         if (d < repo.getGameOverRadiusMeters()) {
-            LocalBroadcastManager.getInstance(app).sendBroadcast(new Intent("ACTION_GAME_OVER"));
+            LocalBroadcastManager.getInstance(app).sendBroadcast(
+                    new Intent(GameService.ACTION_GAME_OVER));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Define ACTION_GAME_STATE_UPDATE and ACTION_GAME_OVER in GameService
- Replace string literals with shared broadcast constants in SnailPhysics, GameActivity, and MainActivity
- Consolidate GameActivity.onStart to a single IntentFilter and compare broadcast actions via constants
- Add clearSavedState utility in GameService and invoke it from MainMenuActivity

## Testing
- ⚠️ `./gradlew test` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06f3390208325983bdcd3459364d1