### PR TITLE
Notify user when snail catches them with screen off

### DIFF
--- a/app/src/main/java/com/example/itfollows/SnailPhysics.java
+++ b/app/src/main/java/com/example/itfollows/SnailPhysics.java
@@ -1,8 +1,16 @@
 package com.example.itfollows;
 
+import android.app.ActivityManager;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.os.PowerManager;
 
+import androidx.core.app.NotificationCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 public class SnailPhysics {
@@ -52,6 +60,50 @@ public class SnailPhysics {
         if (d < repo.getGameOverRadiusMeters()) {
             LocalBroadcastManager.getInstance(app).sendBroadcast(
                     new Intent(GameService.ACTION_GAME_OVER));
+
+            PowerManager pm = (PowerManager) app.getSystemService(Context.POWER_SERVICE);
+            boolean screenOn = pm != null && pm.isInteractive();
+            boolean foreground = isAppInForeground();
+            if (!screenOn || !foreground) {
+                showCaughtNotification();
+            }
         }
+    }
+
+    private boolean isAppInForeground() {
+        ActivityManager am = (ActivityManager) app.getSystemService(Context.ACTIVITY_SERVICE);
+        if (am == null) return false;
+        for (ActivityManager.RunningAppProcessInfo info : am.getRunningAppProcesses()) {
+            if (info.processName.equals(app.getPackageName())) {
+                int imp = info.importance;
+                return imp == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND ||
+                        imp == ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE;
+            }
+        }
+        return false;
+    }
+
+    private void showCaughtNotification() {
+        String channelId = "snail_caught_channel";
+        NotificationManager nm = (NotificationManager) app.getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm == null) return;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel ch = new NotificationChannel(channelId, "Snail Alerts", NotificationManager.IMPORTANCE_HIGH);
+            nm.createNotificationChannel(ch);
+        }
+
+        Intent intent = new Intent(app, GameActivity.class);
+        PendingIntent pi = PendingIntent.getActivity(app, 0, intent, PendingIntent.FLAG_IMMUTABLE);
+
+        Notification notification = new NotificationCompat.Builder(app, channelId)
+                .setSmallIcon(R.drawable.snail)
+                .setContentTitle("The snail caught you")
+                .setContentText("Tap to see what happened.")
+                .setAutoCancel(true)
+                .setContentIntent(pi)
+                .build();
+
+        nm.notify(2001, notification);
     }
 }


### PR DESCRIPTION
## Summary
- send local notification when the snail catches the player and the screen is off
- check screen state via `PowerManager` before notifying
- also alert when the game is not in the foreground

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c198c69f3c8325bdbae0cb77271367