### PR TITLE
Add proximity warning notification for snail

### DIFF
--- a/app/src/main/java/com/example/itfollows/GameStateRepo.java
+++ b/app/src/main/java/com/example/itfollows/GameStateRepo.java
@@ -82,6 +82,14 @@ public class GameStateRepo {
         return 0.6;
     }
 
+    public boolean isSnailProximityAlertShown() {
+        return sp.getBoolean("snailProximityAlertShown", false);
+    }
+
+    public void setSnailProximityAlertShown(boolean shown) {
+        sp.edit().putBoolean("snailProximityAlertShown", shown).apply();
+    }
+
     public void flush() {
         // no-op; using apply()
     }


### PR DESCRIPTION
## Summary
- add shared preference plumbing to remember whether the 25 m proximity alert has already been shown
- raise a background notification when the snail closes within 25 m, and reset the flag once the player opens the distance again
- reuse a helper to provision the shared "Snail Alerts" channel before emitting either notification

## Testing
- ./gradlew test *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c15b6c8832587bd5041c2a2f757