### PR TITLE
Declare AD_ID permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
     <uses-feature android:name="android.hardware.touchscreen" android:required="true"
         tools:ignore="UnsupportedTvHardware" />


### PR DESCRIPTION
## Summary
- add the Google Play services advertising ID permission to the manifest so the app can request the identifier on Android 13+

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc6b17fa388325bed0159d917089ab