### PR TITLE
Remove action bar banner from activities

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.ItFollows" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.ItFollows" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.ItFollows" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.ItFollows" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>


### PR DESCRIPTION
## Summary
- update the day and night themes to use the MaterialComponents NoActionBar variant
- rely on the full-screen layouts so the default title banner with the activity label is no longer shown

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4f3cf13c832594912c1a0feba344