### PR TITLE
Add map recenter button

### DIFF
--- a/app/src/main/java/com/itfollows/game/GameActivity.java
+++ b/app/src/main/java/com/itfollows/game/GameActivity.java
@@ -51,6 +51,7 @@ import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
+import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
@@ -612,6 +613,20 @@ public class GameActivity extends AppCompatActivity implements OnMapReadyCallbac
             // Re-enable following the player and zoom out enough so the snail is visible
             isFollowingPlayer = true;
             zoomOutToShowSnailButKeepPlayerCentered();
+        });
+
+        ImageButton centerPlayerButton = findViewById(R.id.centerPlayerButton);
+        centerPlayerButton.setOnClickListener(v -> {
+            if (mMap == null || currentPlayerLocation == null) {
+                Toast.makeText(this, "Waiting for player location...", Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            isFollowingPlayer = true;
+            CameraPosition cameraPosition = mMap.getCameraPosition();
+            float currentZoom = cameraPosition != null ? cameraPosition.zoom : 18f;
+            CameraUpdate update = CameraUpdateFactory.newLatLngZoom(currentPlayerLocation, currentZoom);
+            mMap.animateCamera(update);
         });
 
 

--- a/app/src/main/res/drawable/ic_my_location.xml
+++ b/app/src/main/res/drawable/ic_my_location.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,8c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4 -1.79,-4 -4,-4zm8.94,3c-0.46,-4.17 -3.77,-7.48 -7.94,-7.94L13,2h-2v1.06C6.83,3.52 3.52,6.83 3.06,11L2,11v2h1.06c0.46,4.17 3.77,7.48 7.94,7.94L11,22h2v-1.06c4.17,-0.46 7.48,-3.77 7.94,-7.94L22,13v-2h-1.06zM12,20c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z" />
+</vector>

--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -52,6 +52,23 @@
         android:src="@drawable/ic_zoom_snail"
         map:tint="#FFFFFF" />
 
+    <ImageButton
+        android:id="@+id/centerPlayerButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/zoomFitButton"
+        android:layout_alignParentEnd="true"
+        android:layout_marginStart="17dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="14dp"
+        android:layout_marginBottom="17dp"
+        android:background="@drawable/zoom_button_background"
+        android:backgroundTint="#AA000000"
+        android:contentDescription="Center map on player"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_my_location"
+        map:tint="#FFFFFF" />
+
     <Button
         android:id="@+id/inventoryButton"
         android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- add a recenter button to the map layout so players can quickly focus on their location
- hook the new button up in `GameActivity` to resume following the player and animate the camera
- provide a vector drawable icon for the new recenter control

## Testing
- ./gradlew lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd819ac4dc83258f20e74e58ed3d76